### PR TITLE
Update languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,13 @@
 
 This binding currently works for cuml 24.06.01.
 
-## Prerequirements
+## Requirements
 
-### install depencencies
+### Language Versions
+
+- Go 1.23 or later
+- Rust 1.70 or later
+
+### Install dependencies
 
 install depencencies  (see [.devcontainer/Dockerfile](.devcontainer/Dockerfile))

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/getumen/cuml-bindings/go
 
-go 1.21.0
+go 1.23
 
 require github.com/stretchr/testify v1.9.0
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cuml-rs"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.70"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,8 +7,8 @@ rust-version = "1.70"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.75"
-thiserror = "1.0.47"
+anyhow = "1.0"
+thiserror = "1.0"
 
 [build-dependencies]
 bindgen = "0.69"


### PR DESCRIPTION
This pull request updates the minimum required versions for Go and Rust, and clarifies the requirements and dependencies in the documentation. The most important changes are grouped below:

**Language Version Updates:**

* Updated the minimum required Go version to 1.23 in `go/go.mod` and documented this requirement in `README.md`. [[1]](diffhunk://#diff-340a0a599142950de3cef119fa68e93ef2350dbab23edaa3c7e561899e9ea399L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R12)
* Added a minimum Rust version of 1.70 in `rust/Cargo.toml` and documented this requirement in `README.md`. [[1]](diffhunk://#diff-74eb46d64310c0817ed15b2389cf81183c18cdebbaa256a4198057855ecf14d7R5-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R12)

**Documentation Improvements:**

* Clarified and corrected the "Requirements" section in `README.md`, including fixing typos and improving the formatting of dependency installation instructions.

**Dependency Version Simplification:**

* Updated `anyhow` and `thiserror` dependencies in `rust/Cargo.toml` to use the latest 1.0 versions instead of specific patch versions.